### PR TITLE
fix link in logo icon

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -75,7 +75,7 @@ const config = {
 					alt: 'KUOSC Logo',
 					src: 'img/logo.svg',
 					srcDark: 'img/logo.svg',
-					href: 'https://kuosc.org.np/'
+					href: '/'
 				},
 				items: [
 					{


### PR DESCRIPTION
![image](https://github.com/kuosc2005/website/assets/73330912/1ddeabae-6b9d-49dd-841a-9b3effd2e4f2)
Clicking on the logo previously would open a new tab, which is not the expected behavior. So, that has been fixed.