### PR TITLE
FIX: set 'blogSidebarCount' in docusaurus.config.js as 'ALL' to include all posts

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,7 +43,8 @@ const config = {
 				},
 
 				blog: {
-					showReadingTime: true
+					showReadingTime: true,
+					blogSidebarCount: 'ALL'
 				},
 				theme: {
 					customCss: require.resolve('./src/css/custom.css')


### PR DESCRIPTION

## Checklist
- [ ] Documentation is updated if necessary.
- [x] The change(s) has/have been tested locally.


## Description
set the 'blogSidebarCount' in docusaurus.config.js as 'ALL' to include all posts in the sidebar. fixes #69 


## Related Issues
Fixes #69 

## Changes Made
- Main Change 1: set the 'blogSidebarCount' in docusaurus.config.js as 'ALL' to include all posts in the sidebar

## Notes for Reviewers

it needs to be discussed whether having all posts listed on the sidebar is desired or not. 
considering that there aren't many posts as of now, and that all posts are being rendered on the blog's index page,  I, personally, don't think it could be that big of an issue to include all posts in the sidebar. 

- [x] Is this ready to be merged?  


## Screenshots / Media (Optional)
<img width="1353" height="748" alt="image" src="https://github.com/user-attachments/assets/e56f6866-b2f9-4a5a-8f9e-ae057f4afdfb" />
